### PR TITLE
Multiple public ticket creation support

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,6 @@
+backup
+./docker-compose.yml
+./Dockerfile
+./LICENSE
+./README.md
+./CHANGELOG.md

--- a/.rgignore
+++ b/.rgignore
@@ -1,0 +1,16 @@
+mobile/**
+logs/**
+.yarn/**/*
+docs/**
+src/public/css/**
+src/public/css/**/*
+src/public/js/plugins/**
+src/public/js/plugins/**/*
+src/public/js/vendor/**
+src/public/js/vendor/**/*
+public/**
+public/**/*
+test/**/*
+.github/**/*
+CHANGELOG.md
+README.md

--- a/jsconfig.json
+++ b/jsconfig.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "resolveJsonModule": true,
     "rootDir": "./",
     "baseUrl": "./src",
     "checkJs": true,

--- a/src/controllers/api/v1/routes.js
+++ b/src/controllers/api/v1/routes.js
@@ -117,7 +117,8 @@ module.exports = function (middleware, router, controllers) {
   const checkOrigin = middleware.checkOrigin
 
   router.post('/api/v1/public/users/checkemail', checkCaptcha, checkOrigin, apiCtrl.users.checkEmail)
-  router.post('/api/v1/public/tickets/create', checkCaptcha, checkOrigin, apiCtrl.tickets.createPublicTicket)
+  // TODO: renable some kind of user verification instead of captcha
+  router.post('/api/v1/public/tickets/create', apiCtrl.tickets.createPublicTicket)
   router.post('/api/v1/public/account/create', checkCaptcha, checkOrigin, apiCtrl.users.createPublicAccount)
 
   // Groups

--- a/src/controllers/api/v1/routes.js
+++ b/src/controllers/api/v1/routes.js
@@ -103,7 +103,7 @@ module.exports = function (middleware, router, controllers) {
     tagSchema.countDocuments({}, function (err, count) {
       if (err) return res.status(500).json({ success: false, error: err })
 
-      return res.json({ success: true, count: count })
+      return res.json({ success: true, count })
     })
   })
 

--- a/src/controllers/api/v1/tickets.js
+++ b/src/controllers/api/v1/tickets.js
@@ -534,11 +534,14 @@ apiTickets.createPublicTicket = function (req, res) {
   const chance = new Chance()
   const response = {}
   response.success = true
+
+  /** @type {{user: any, ticket: any}} */
   const postData = req.body
   if (!_.isObject(postData)) {
     return res.status(400).json({ success: false, error: 'Invalid Post Data' })
   }
-  let user, group, ticket, plainTextPass
+  let plainTextPass
+  let existingUser = false
 
   const settingSchema = require('../../../models/setting')
 
@@ -566,54 +569,55 @@ apiTickets.createPublicTicket = function (req, res) {
           return next(null, roleDefault)
         })
       },
-      function (roleDefault, next) {
+      async function (roleDefault) {
         const UserSchema = require('../../../models/user')
+        let user = await UserSchema.getUserByEmail(postData.user.email)
+        if (user) {
+          existingUser = true
+          return user
+        }
+
         plainTextPass = chance.string({
           length: 6,
           pool: 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz1234567890'
         })
 
-        const sanitizedFullname = xss(postData.user.fullname)
-
         user = new UserSchema({
           username: postData.user.email,
           password: plainTextPass,
-          fullname: sanitizedFullname,
+          fullname: xss(postData.user.fullname),
           email: postData.user.email,
           accessToken: chance.hash(),
           role: roleDefault.value
         })
 
-        user.save(function (err, savedUser) {
-          if (err) return next(err)
-
-          return next(null, savedUser)
-        })
+        return await user.save()
       },
 
-      function (savedUser, next) {
+      async function (user) {
         // Group Creation
         const GroupSchema = require('../../../models/group')
-        group = new GroupSchema({
-          name: savedUser.email,
-          members: [savedUser._id],
-          sendMailTo: [savedUser._id],
+        if (existingUser) {
+          const group = await GroupSchema.getGroupByNameNoPopulate(user.email)
+          if (group) {
+            return [group, user]
+          }
+        }
+        const group = await new GroupSchema({
+          name: user.email,
+          members: [user._id],
+          sendMailTo: [user._id],
           public: true
-        })
-
-        group.save(function (err, group) {
-          if (err) return next(err)
-
-          return next(null, group, savedUser)
-        })
+        }).save()
+        return [group, user]
       },
-      function (group, savedUser, next) {
+      function ([group, user], next) {
         const settingsSchema = require('../../../models/setting')
         settingsSchema.getSettingByName('ticket:type:default', function (err, defaultType) {
           if (err) return next(err)
 
           if (defaultType.value) {
-            return next(null, defaultType.value, group, savedUser)
+            return next(null, defaultType.value, group, user)
           }
 
           return next('Failed: Invalid Default Ticket Type.')
@@ -649,7 +653,7 @@ apiTickets.createPublicTicket = function (req, res) {
           description: 'Ticket was created.',
           owner: savedUser._id
         }
-        ticket = new TicketSchema({
+        const ticket = new TicketSchema({
           owner: savedUser._id,
           group: group._id,
           type: ticketType._id,
@@ -687,9 +691,16 @@ apiTickets.createPublicTicket = function (req, res) {
       delete result.user.password
       result.user.password = undefined
 
+      const userData = {}
+      userData.newUser = !existingUser
+      userData.user = result.user 
+      if (!existingUser) {
+        userData.chancepass = plainTextPass
+      }
+
       return res.json({
         success: true,
-        userData: { savedUser: result.user, chancepass: plainTextPass },
+        userData,
         ticket: result.ticket
       })
     }

--- a/src/controllers/api/v1/tickets.js
+++ b/src/controllers/api/v1/tickets.js
@@ -693,7 +693,7 @@ apiTickets.createPublicTicket = function (req, res) {
 
       const userData = {}
       userData.newUser = !existingUser
-      userData.user = result.user 
+      userData.savedUser = result.user 
       if (!existingUser) {
         userData.chancepass = plainTextPass
       }

--- a/src/models/group.js
+++ b/src/models/group.js
@@ -142,6 +142,15 @@ groupSchema.statics.getGroupByName = function (name, callback) {
   return q.exec(callback)
 }
 
+groupSchema.statics.getGroupByNameNoPopulate = async function(name) {
+  if (_.isUndefined(name) || name.length < 1) {
+    throw new Error('Invalid Group Name - GroupSchema.GetGroupByName()')
+  }
+  return this.model(COLLECTION)
+    .findOne({ name })
+    .exec()
+}
+
 groupSchema.statics.getWithObject = function (obj, callback) {
   var limit = obj.limit ? Number(obj.limit) : 100
   var page = obj.page ? Number(obj.page) : 0


### PR DESCRIPTION
- Adds support for the same email to create multiple tickets from public ticket creation API without logging in.
- disables captcha and origin check for public ticket creation API
- adds dockerignore and rgignore files